### PR TITLE
New react-scripts fork

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-scripts",
-  "version": "3.0.1",
-  "description": "Configuration and scripts for Create React App.",
+  "name": "websked-react-scripts",
+  "version": "3.0.2",
+  "description": "Arc WebSked Fork of Configuration and scripts for Create React App.",
   "homepage": "/test",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/wpmedia/create-react-app.git",
     "directory": "packages/react-scripts"
   },
   "license": "MIT",
@@ -13,7 +13,7 @@
     "node": ">=8.10"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/wpmedia/create-react-app/issues"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This is based on the branch created by `iamandrewluca` to serve from non-root paths; see this PR: https://github.com/facebook/create-react-app/pull/7259

Most of the modifications are his. The only additional thing that needs to be changed is removing a property he was passing to the webpack dev server to allow serving static assets from non-root paths. This is not yet supported by webpack (he has an outstanding PR with that team). Since we don't serve any assets out of `public`, we don't appear to need this.

The `react-scripts` package is published to npm as `websked-react-scripts`, which can then be imported into the Collections repo (See https://github.com/WPMedia/arc-collections/pull/254).